### PR TITLE
fix: remove hardcoded `constrctor.name` check

### DIFF
--- a/packages/near-transaction-manager/src/creator/KeyStoreTransactionCreator.ts
+++ b/packages/near-transaction-manager/src/creator/KeyStoreTransactionCreator.ts
@@ -116,12 +116,6 @@ export class KeyStoreTransactionCreator implements TransactionCreator {
    * Create an instance of `KeyStoreTransactionCreator` from a NEAR `Account`.
    */
   static fromAccount(account: Account): KeyStoreTransactionCreator {
-    if (account.connection.signer.constructor.name !== "InMemorySigner") {
-      throw new Error(
-        "Account doesn't use an InMemorySigner. No key store can be found."
-      );
-    }
-
     const { keyStore } = account.connection.signer as unknown as InMemorySigner;
     return new KeyStoreTransactionCreator({
       keyStore,

--- a/packages/near-transaction-manager/src/signer/KeyStoreTransactionSigner.ts
+++ b/packages/near-transaction-manager/src/signer/KeyStoreTransactionSigner.ts
@@ -79,12 +79,6 @@ export class KeyStoreTransactionSigner implements TransactionSigner {
    * Create an instance of `KeyStoreTransactionSigner` from a NEAR `Account`.
    */
   static fromAccount(account: Account): KeyStoreTransactionSigner {
-    if (account.connection.signer.constructor.name !== "InMemorySigner") {
-      throw new Error(
-        "Account doesn't use an InMemorySigner. No key store can be found."
-      );
-    }
-
     const { keyStore } = account.connection.signer as unknown as InMemorySigner;
     return new KeyStoreTransactionSigner({
       keyStore,


### PR DESCRIPTION
Rationale: this breaks for in-browser usage because constructor name
gets minified.